### PR TITLE
feat: add PDF export and release workflow

### DIFF
--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -1,0 +1,74 @@
+name: Build PDF & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号 (如 v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm install puppeteer pdf-lib
+
+      - name: Install Chrome dependencies
+        run: npx puppeteer browsers install chrome
+
+      - name: Export PDF
+        run: node scripts/export-pdf.mjs
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "Hello Generic Agent 教程 ${{ steps.version.outputs.tag }}"
+          body: |
+            ## 📖 Hello Generic Agent 教程 PDF 版本
+
+            从安装到原理，全面掌握以"上下文信息密度最大化"为核心的 Generic Agent。
+
+            ### 📥 下载
+            下载下方 `hello-generic-agent.pdf` 即可离线阅读。
+
+            ### 📚 内容包含
+            - Part 1：应用篇（第1-6章）
+            - Part 2：原理篇（第7-13章）
+            - Part 3：实战篇（Case 1）
+
+            ---
+            🌐 [在线阅读](https://datawhalechina.github.io/hello-generic-agent/)
+          files: hello-generic-agent.pdf
+          draft: false
+          prerelease: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "export:pdf": "node scripts/export-pdf.mjs"
   },
   "dependencies": {
     "vitepress-plugin-image-viewer": "^1.1.6"

--- a/scripts/export-pdf.mjs
+++ b/scripts/export-pdf.mjs
@@ -1,0 +1,123 @@
+import { execSync, spawn } from 'child_process';
+import { readFileSync, mkdirSync, existsSync } from 'fs';
+import puppeteer from 'puppeteer';
+import { PDFDocument } from 'pdf-lib';
+import { writeFile } from 'fs/promises';
+
+// 章节顺序（与 sidebar 一致）
+const chapters = [
+  '/part1/chapter1/',
+  '/part1/chapter2/',
+  '/part1/chapter3/',
+  '/part1/chapter4/',
+  '/part1/chapter5/',
+  '/part1/chapter6/',
+  '/part2/chapter7/',
+  '/part2/chapter8/',
+  '/part2/chapter9/',
+  '/part2/chapter10/',
+  '/part2/chapter11/',
+  '/part2/chapter12/',
+  '/part2/chapter13/',
+  '/part3/chapter14/',
+];
+
+const BASE = '/hello-generic-agent';
+const PORT = 4173; // vitepress preview port
+const OUTPUT_DIR = 'pdf-output';
+const FINAL_PDF = 'hello-generic-agent.pdf';
+
+async function waitForServer(url, timeout = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(`Server not ready at ${url} after ${timeout}ms`);
+}
+
+async function main() {
+  // 1. Build VitePress
+  console.log('📦 Building VitePress site...');
+  execSync('npm run docs:build', { stdio: 'inherit' });
+
+  // 2. Start preview server
+  console.log('🚀 Starting preview server...');
+  const server = spawn('npx', ['vitepress', 'preview', 'docs', '--port', String(PORT)], {
+    stdio: 'pipe',
+    detached: false,
+  });
+
+  const baseUrl = `http://localhost:${PORT}${BASE}`;
+  await waitForServer(baseUrl);
+  console.log(`✅ Server ready at ${baseUrl}`);
+
+  // 3. Launch Puppeteer
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const pdfBuffers = [];
+
+  for (const chapter of chapters) {
+    const url = `http://localhost:${PORT}${BASE}${chapter}`;
+    console.log(`📄 Exporting: ${chapter}`);
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+
+    // Hide sidebar and nav for cleaner PDF
+    await page.addStyleTag({
+      content: `
+        .VPSidebar, .VPNav, .VPFooter, .edit-link, .prev-next { display: none !important; }
+        .VPDoc { padding-left: 0 !important; }
+        .VPContent { max-width: 100% !important; padding: 0 40px !important; }
+        @media print {
+          .VPSidebar, .VPNav, .VPFooter, .edit-link, .prev-next { display: none !important; }
+        }
+      `,
+    });
+
+    // Wait for images and math to render
+    await page.waitForTimeout(2000);
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' },
+    });
+
+    pdfBuffers.push(pdf);
+    await page.close();
+  }
+
+  await browser.close();
+  server.kill();
+
+  // 4. Merge PDFs
+  console.log('📎 Merging PDFs...');
+  const mergedPdf = await PDFDocument.create();
+
+  for (const buffer of pdfBuffers) {
+    const doc = await PDFDocument.load(buffer);
+    const pages = await mergedPdf.copyPages(doc, doc.getPageIndices());
+    pages.forEach(p => mergedPdf.addPage(p));
+  }
+
+  mergedPdf.setTitle('Hello Generic Agent 教程');
+  mergedPdf.setAuthor('Datawhale');
+  mergedPdf.setSubject('从安装到原理，全面掌握 Generic Agent');
+
+  const mergedBytes = await mergedPdf.save();
+  await writeFile(FINAL_PDF, mergedBytes);
+  console.log(`✅ Done! Output: ${FINAL_PDF} (${(mergedBytes.length / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+main().catch(err => {
+  console.error('❌ Export failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 变更内容

- 新增 `scripts/export-pdf.mjs`：Puppeteer 逐章导出 + pdf-lib 合并为完整 PDF
- 新增 `.github/workflows/release-pdf.yml`：手动触发或打 tag 时自动生成 PDF 并发布 GitHub Release
- 更新 `package.json`：添加 `export:pdf` 脚本

## 使用方式

1. 合并后到 Actions → Build PDF & Release → Run workflow → 输入版本号
2. 或者打 tag（如 `v1.0.0`）自动触发

生成的 PDF 会自动附到 GitHub Release 页面。